### PR TITLE
Require lcobucci/jwt at least 4.3 and allow 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "lcobucci/jwt": "^4.0",
+        "lcobucci/jwt": "^4.3|^5.0",
         "league/oauth2-server": "^8.2.0",
         "laravel/passport": "^11.0",
         "laravel/framework": "^10.0"


### PR DESCRIPTION
This pull request updates the requirement for `lcobucci/jwt` from `^4.0` to `^4.3|^5.0`. I used `^4.3` because [the documentation](https://lcobucci-jwt.readthedocs.io/en/stable/upgrading/ ) says, "We're adding a few deprecation annotations on the version v4.3.0. So, before going to v5.0.0 please update to the latest 4.3.x version using composer:" I read through the upgrade guide and didn't find anything that needs to change for things to work with 5.x. Additionally, chose these values because `laravel/passport` [uses them](https://github.com/laravel/passport/blob/11.x/composer.json#L29) and because `league/oauth2-server` [basically uses them](https://github.com/thephpleague/oauth2-server/blob/master/composer.json#L11).