### PR TITLE
Test fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 .phpunit.result.cache
+.phpunit.cache
 composer.lock
 tmp/
 .phplint-cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,28 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    colors="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    stopOnError="true"
-    stopOnFailure="true"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    testdox="true"
-    bootstrap="tests/Bootstrap.php">
-
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-
-    <coverage includeUncoveredFiles="true">
-      <include>
-        <directory suffix=".php">src</directory>
-      </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" colors="true" stopOnError="true" stopOnFailure="true" stopOnIncomplete="false" stopOnSkipped="false" testdox="true" bootstrap="tests/Bootstrap.php" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <coverage includeUncoveredFiles="true"/>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/Feature/ClaimExtractorTest.php
+++ b/tests/Feature/ClaimExtractorTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ClaimExtractorTest extends TestCase
 {
-    public function protected_claim_sets()
+    public static function protected_claim_sets()
     {
         yield 'profile' => ['name' => 'profile'];
         yield 'email' => ['name' => 'email'];

--- a/tests/Feature/IdTokenTest.php
+++ b/tests/Feature/IdTokenTest.php
@@ -56,6 +56,7 @@ class IdTokenTest extends TestCase
         $json = json_decode($response->getBody()->getContents());
         $this->defaultTokenAsserts($json);
 
-        $this->assertObjectHasAttribute('id_token', $json);
+        $this->assertIsObject($json);
+        $this->assertTrue(property_exists($json, 'id_token'));
     }
 }

--- a/tests/Feature/OauthTest.php
+++ b/tests/Feature/OauthTest.php
@@ -23,6 +23,7 @@ class OauthTest extends TestCase
         $json = json_decode($response->getBody()->getContents());
         $this->defaultTokenAsserts($json);
 
-        $this->assertObjectNotHasAttribute('id_token', $json);
+        $this->assertIsObject($json);
+        $this->assertTrue(!property_exists($json, 'id_token'));
     }
 }

--- a/tests/Feature/OauthTest.php
+++ b/tests/Feature/OauthTest.php
@@ -24,6 +24,6 @@ class OauthTest extends TestCase
         $this->defaultTokenAsserts($json);
 
         $this->assertIsObject($json);
-        $this->assertTrue(!property_exists($json, 'id_token'));
+        $this->assertFalse(property_exists($json, 'id_token'));
     }
 }

--- a/tests/Feature/Traits/WithDefaultAsserts.php
+++ b/tests/Feature/Traits/WithDefaultAsserts.php
@@ -23,7 +23,9 @@ trait WithDefaultAsserts
     {
         $this->assertSame('Bearer', $json->token_type);
         $this->assertSame(3600, $json->expires_in);
-        $this->assertObjectHasAttribute('access_token', $json);
-        $this->assertObjectHasAttribute('refresh_token', $json);
+        $this->assertIsObject($json);
+        $this->assertTrue(property_exists($json, 'access_token'));
+        $this->assertTrue(property_exists($json, 'refresh_token'));
+
     }
 }


### PR DESCRIPTION
- I replaced `assertObjectHasAttribute()` with `assertIsObject()` & `assertTrue(property_exists($json, 'thing we are looking for'))`
- I replaced `assertObjectNotHasAttribute()` with `assertIsObject()` & `assertFalse(property_exists($json, 'thing we are looking for'))`
- Set the `protected_claim_sets()` function to `static`.
- Migrated the PHPUnit XML configuration.


## Before
```
PHPUnit 10.3.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.8
Configuration: laravel-openid-connect/phpunit.xml

D..............................E

Time: 00:00.171, Memory: 24.45 MB

Claim Extractor (OpenIDConnect\Tests\Feature\ClaimExtractor)
 ✔ Default claim sets exist with profile
 ✔ Default claim sets exist with email
 ✔ Default claim sets exist with address
 ✔ Default claim sets exist with phone
 ✔ Cannot override protected scope with profile
 ✔ Cannot override protected scope with email
 ✔ Cannot override protected scope with address
 ✔ Cannot override protected scope with phone
 ✔ Can get scope by name with profile
 ✔ Can get scope by name with email
 ✔ Can get scope by name with address
 ✔ Can get scope by name with phone
 ✔ Can set and extract custom claim set
 ✔ Can safely get uknown claim set
 ✔ Can safely extract uknown claim
 ✔ Can safely extract known claim set
 ✔ Can safely extract invalid claim set

Configuration (OpenIDConnect\Tests\Feature\Configuration)
 ✔ Can create configurations
 ✔ Can create configurations with key from text
 ✔ Configuration needs correct signer key path

Id Token (OpenIDConnect\Tests\Feature\IdToken)
 ✔ Can create id token responses
 ✔ Can create id token responses with openid claim set
 ✘ Receive id token with open id scope
   ┐
   ├ Error: Call to undefined method OpenIDConnect\Tests\Feature\IdTokenTest::assertObjectHasAttribute()
   │
   │ laravel-openid-connect/tests/Feature/Traits/WithDefaultAsserts.php:26
   │ laravel-openid-connect/tests/Feature/IdTokenTest.php:57
   ┴

Identity Entity (OpenIDConnect\Tests\Unit\IdentityEntity)
 ✔ Identity entity has claims property
 ✔ Identity entity has get claims method
 ✔ Identity entity has set claims method
 ✔ Identity entity has identifier property
 ✔ Identity entity has get identifier method
 ✔ Identity entity has set identifier method

Scope Entity (OpenIDConnect\Tests\Unit\ScopeEntity)
 ✔ Scope has entity identifier property
 ✔ Scope entity has get identifier method
 ✔ Scope entity set identifier method

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

--

3 tests triggered 3 PHPUnit deprecations:

1) OpenIDConnect\Tests\Feature\ClaimExtractorTest::test_default_claim_sets_exist
Data Provider method OpenIDConnect\Tests\Feature\ClaimExtractorTest::protected_claim_sets() is not static

laravel-openid-connect/tests/Feature/ClaimExtractorTest.php:23

2) OpenIDConnect\Tests\Feature\ClaimExtractorTest::test_cannot_override_protected_scope
Data Provider method OpenIDConnect\Tests\Feature\ClaimExtractorTest::protected_claim_sets() is not static

laravel-openid-connect/tests/Feature/ClaimExtractorTest.php:32

3) OpenIDConnect\Tests\Feature\ClaimExtractorTest::test_can_get_scope_by_name
Data Provider method OpenIDConnect\Tests\Feature\ClaimExtractorTest::protected_claim_sets() is not static

laravel-openid-connect/tests/Feature/ClaimExtractorTest.php:42

ERRORS!
Tests: 32, Assertions: 43, Errors: 1, Deprecations: 4, Notices: 1.
```

## After

```
PHPUnit 10.3.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.8
Configuration: laravel-openid-connect/phpunit.xml

...............................NNNNN                              36 / 36 (100%)

Time: 00:00.793, Memory: 24.45 MB

Claim Extractor (OpenIDConnect\Tests\Feature\ClaimExtractor)
 ✔ Default claim sets exist with profile
 ✔ Default claim sets exist with email
 ✔ Default claim sets exist with address
 ✔ Default claim sets exist with phone
 ✔ Cannot override protected scope with profile
 ✔ Cannot override protected scope with email
 ✔ Cannot override protected scope with address
 ✔ Cannot override protected scope with phone
 ✔ Can get scope by name with profile
 ✔ Can get scope by name with email
 ✔ Can get scope by name with address
 ✔ Can get scope by name with phone
 ✔ Can set and extract custom claim set
 ✔ Can safely get uknown claim set
 ✔ Can safely extract uknown claim
 ✔ Can safely extract known claim set
 ✔ Can safely extract invalid claim set

Configuration (OpenIDConnect\Tests\Feature\Configuration)
 ✔ Can create configurations
 ✔ Can create configurations with key from text
 ✔ Configuration needs correct signer key path

Id Token (OpenIDConnect\Tests\Feature\IdToken)
 ✔ Can create id token responses
 ✔ Can create id token responses with openid claim set
 ✔ Receive id token with open id scope

Identity Entity (OpenIDConnect\Tests\Unit\IdentityEntity)
 ✔ Identity entity has claims property
 ✔ Identity entity has get claims method
 ✔ Identity entity has set claims method
 ✔ Identity entity has identifier property
 ✔ Identity entity has get identifier method
 ✔ Identity entity has set identifier method

Oauth (OpenIDConnect\Tests\Feature\Oauth)
 ✔ Default response has no id token

Scope Entity (OpenIDConnect\Tests\Unit\ScopeEntity)
 ✔ Scope has entity identifier property
 ✔ Scope entity has get identifier method
 ✔ Scope entity set identifier method

Tokens (OpenIDConnect\Tests\Feature\Tokens)
 ✔ Id token is valid
 ✔ Id token with email scope returns email claim
 ✔ Id token with custom scope returns custom claim

OK, but there were issues!
Tests: 36, Assertions: 86, Notices: 1.