### PR TITLE
Allow Custom Token Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ In case you want to change the default scopes, add custom claim sets or change t
 php artisan vendor:publish --tag=openid
 ```
 
+### Optional Configuration
+You can add any JWT Token Headers that you want to the `token_headers` array in your `openid` configuration file.
+
+This can be useful to define things like the [`kid`(Key ID)](https://datatracker.ietf.org/doc/html/rfc7517#section-4.5).  The `kid` can be any string as long as it can uniquely identify the key you want to use in your [JWKS](https://datatracker.ietf.org/doc/html/rfc7517#section-5). This can be useful when changing or rolling keys.
+
+Example:
+
+```php
+'token_headers' => ['kid' => base64_encode('public-key-added-2023-01-01')]
+```
+
 ## Support
 
 You can fill an issue in the github section dedicated for that. I'll try to maintain this fork.

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -20,14 +20,18 @@ class IdTokenResponse extends BearerTokenResponse
 
     private Configuration $config;
 
+    private array $tokenHeaders;
+
     public function __construct(
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
-        Configuration $config
+        Configuration $config,
+        array $tokenHeaders = []
     ) {
         $this->identityRepository = $identityRepository;
         $this->claimExtractor = $claimExtractor;
         $this->config = $config;
+        $this->tokenHeaders = $tokenHeaders;
     }
 
     protected function getBuilder(
@@ -56,6 +60,10 @@ class IdTokenResponse extends BearerTokenResponse
         );
 
         $builder = $this->getBuilder($accessToken, $user);
+
+        foreach ($this->tokenHeaders as $key => $value) {
+            $builder = $builder->withHeader($key, $value);
+        }
 
         $claims = $this->claimExtractor->extract(
             $accessToken->getScopes(),

--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -51,6 +51,7 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
                 app(config('openid.signer')),
                 InMemory::file($cryptKey->getKeyPath()),
             ),
+            config('openid.token_headers'),
         );
 
         return new AuthorizationServer(

--- a/src/Laravel/config/openid.php
+++ b/src/Laravel/config/openid.php
@@ -43,4 +43,9 @@ return [
      * The signer to be used
      */
 	'signer' => \Lcobucci\JWT\Signer\Rsa\Sha256::class,
+
+    /**
+     * Optional associative array that will be used to set headers on the JWT
+     */
+    'token_headers' => [],
 ];


### PR DESCRIPTION
This allows you to set any number of token headers that you would like, including none, via the new `openid.token_headers` configuration parameter. This can be useful for a number of reasons but my primary use is to add the header `kid` with my Key ID value.