### PR TITLE
Make the use of microseconds configurable

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -22,23 +22,30 @@ class IdTokenResponse extends BearerTokenResponse
 
     private array $tokenHeaders;
 
+    private bool $useMicroseconds;
+
     public function __construct(
         IdentityRepositoryInterface $identityRepository,
         ClaimExtractor $claimExtractor,
         Configuration $config,
-        array $tokenHeaders = []
+        array $tokenHeaders = [],
+        bool $useMicroseconds = true
     ) {
         $this->identityRepository = $identityRepository;
         $this->claimExtractor = $claimExtractor;
         $this->config = $config;
         $this->tokenHeaders = $tokenHeaders;
+        $this->useMicroseconds = $useMicroseconds;
     }
 
     protected function getBuilder(
         AccessTokenEntityInterface $accessToken,
         IdentityEntityInterface $userEntity
     ): Builder {
-        $dateTimeImmutableObject = new DateTimeImmutable();
+        $dateTimeImmutableObject = DateTimeImmutable::createFromFormat(
+            ($this->useMicroseconds ? 'U.u' : 'U'),
+            time()
+        );
 
         return $this->config
             ->builder()

--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -52,6 +52,7 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
                 InMemory::file($cryptKey->getKeyPath()),
             ),
             config('openid.token_headers'),
+            config('openid.use_microseconds')
         );
 
         return new AuthorizationServer(

--- a/src/Laravel/config/openid.php
+++ b/src/Laravel/config/openid.php
@@ -48,4 +48,9 @@ return [
      * Optional associative array that will be used to set headers on the JWT
      */
     'token_headers' => [],
+
+    /**
+     * By default, microseconds are included.
+     */
+    'use_microseconds' => true,
 ];


### PR DESCRIPTION
This update adds a new configuration variable `use_microseconds`. It defaults to `true` even if it does not exist so that it does not break backwards compatibility. If you set it to `false` the  `DateTimeImmutable` object that we pass to `issuedAt()` & `expiresAt()` will be built without microseconds.

By removing the microseconds from the `DateTimeImmutable` object, we are letting the `lcobucci/jwt` package know that we want an `int` and not a `float`. You can see this logic in the [MicrosecondBasedDateConversion](https://github.com/lcobucci/jwt/blob/5.1.x/src/Encoding/MicrosecondBasedDateConversion.php#L30) class that `lcobucci/jwt` uses to covert all `RegisteredClaims::DATE_CLAIMS`.

The reason that I think this is need this is because the specification can be interpreted as calling for seconds and not seconds with microseconds. The description for ["iat" (Issued At) Claim](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.6) calls for a "NumericDate value" which is defined at the bottom of the [Terminology section](https://datatracker.ietf.org/doc/html/rfc7519#section-2). That definition even links to [IEEE Std 1003.1, 2013 Edition, 2013](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_16) which clearly notes, "The divisions in the formula are integer divisions; that is, the remainder is discarded leaving only the integer quotient."

Additionally, we are working with an application that is utilizing Google Firebase. We have been in contact with them on continued issues we are having and they recent sent us this: 
```
"Turns out in the third party Google jwt library, the iat field (and other similar "seconds since epoch time" fields) is assumed to be a Long, which means that float values like 123.456 will cause an error.
Can the OIDC provider be configured to return an integer for those fields?"
```