### PR TITLE
fix: use stringified microtime() instead of time()

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -44,7 +44,7 @@ class IdTokenResponse extends BearerTokenResponse
     ): Builder {
         $dateTimeImmutableObject = DateTimeImmutable::createFromFormat(
             ($this->useMicroseconds ? 'U.u' : 'U'),
-            time()
+            strval(microtime(true))
         );
 
         return $this->config


### PR DESCRIPTION
`DateTimeImmutable::createFromFormat` always returned false for me resulting in an exception, this fixes the datetime parameter