### PR TITLE
Use private key contensts instead of key path

### DIFF
--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -49,7 +49,7 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
             new ClaimExtractor(...$claimSets),
             Configuration::forSymmetricSigner(
                 app(config('openid.signer')),
-                InMemory::file($cryptKey->getKeyPath()),
+                InMemory::plainText($cryptKey->getKeyContents(), $cryptKey->getPassPhrase() ?? '')
             ),
             config('openid.token_headers'),
             config('openid.use_microseconds')


### PR DESCRIPTION
This PR changes the way the pass the private key into the IdTokenResponse.

Because some people deploy the Passport keypair as env variables (and not have them in a physical file), the old situation didn't work.

Since Laravel has already loaded the key into memory, we might as well grab the raw contents of the key and pass that along. This PR changes the behaviour to do exactly that.