### PR TITLE
Adding well-known configuration and JWKS routes in Laravel

### DIFF
--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OpenIDConnect\Laravel;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+class DiscoveryController
+{
+    public function __invoke(Request $request)
+    {
+        $response = [
+            'issuer' => url('/'),
+            'authorization_endpoint' => route('passport.authorizations.authorize'),
+            'token_endpoint' => route('passport.token'),
+            'jwks_uri' => route('openid.jwks'),
+            'response_types_supported' => [
+                'code',
+                'token',
+                'id_token',
+                'code token',
+                'code id_token',
+                'token id_token',
+                'code token id_token',
+                'none',
+            ],
+            'subject_types_supported' => [
+                'public',
+            ],
+            'id_token_signing_alg_values_supported' => [
+                'RS256',
+            ],
+            'scopes_supported' => config('openid.passport.tokens_can'),
+            'token_endpoint_auth_methods_supported' => [
+                'client_secret_basic',
+                'client_secret_post',
+            ],
+        ];
+
+        if (Route::has('openid.userinfo')) {
+            $response['userinfo_endpoint'] = route('openid.userinfo');
+        }
+
+        return response()->json($response, 200, [], JSON_PRETTY_PRINT);
+    }
+}

--- a/src/Laravel/JwksController.php
+++ b/src/Laravel/JwksController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace OpenIDConnect\Laravel;
+
+use Illuminate\Config\Repository as Config;
+use Laravel\Passport\Passport;
+
+class JwksController
+{
+    public function __invoke() {
+        $publicKey = $this->getPublicKey();
+
+        // Source: https://www.tuxed.net/fkooman/blog/json_web_key_set.html
+        $keyInfo = openssl_pkey_get_details(openssl_pkey_get_public($publicKey));
+
+        $jsonData = [
+            'keys' => [
+                [
+                    'kty' => 'RSA',
+                    'n' => rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($keyInfo['rsa']['n'])), '='),
+                    'e' => rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($keyInfo['rsa']['e'])), '='),
+                ],
+            ],
+        ];
+
+        return response()->json($jsonData, 200, [], JSON_PRETTY_PRINT);
+    }
+
+    private function getPublicKey(): string {
+        $publicKey = str_replace('\\n', "\n", config('passport.public_key', ''));
+
+        if (!$publicKey) {
+            $publicKey = 'file://'.Passport::keyPath('oauth-public.key');
+        }
+
+        return $publicKey;
+    }
+}

--- a/src/Laravel/PassportServiceProvider.php
+++ b/src/Laravel/PassportServiceProvider.php
@@ -32,6 +32,8 @@ class PassportServiceProvider extends Passport\PassportServiceProvider
         $this->publishes([
             __DIR__ . '/config/openid.php' => $this->app->configPath('openid.php'),
         ], ['openid', 'openid-config']);
+
+        $this->loadRoutesFrom(__DIR__."/routes/web.php");
     }
 
     public function makeAuthorizationServer(): AuthorizationServer

--- a/src/Laravel/config/openid.php
+++ b/src/Laravel/config/openid.php
@@ -39,6 +39,19 @@ return [
         'identity' => \OpenIDConnect\Repositories\IdentityRepository::class,
     ],
 
+    'routes' => [
+        /**
+         * When set to true, this package will expose the OpenID Connect Discovery endpoint.
+         *  - /.well-known/openid-configuration
+         */
+        'discovery' => true,
+        /**
+         * When set to true, this package will expose the JSON Web Key Set endpoint.
+         * - /oauth/jwks
+         */
+        'jwks' => true,
+    ],
+
     /**
      * The signer to be used
      */

--- a/src/Laravel/routes/web.php
+++ b/src/Laravel/routes/web.php
@@ -1,0 +1,7 @@
+<?php
+if (config('openid.routes.discovery', true)) {
+    Route::get('/oauth/jwks', \OpenIDConnect\Laravel\JwksController::class)->name('openid.jwks');
+}
+if (config('openid.routes.jwks', true)) {
+    Route::get('/.well-known/openid-configuration', \OpenIDConnect\Laravel\DiscoveryController::class)->name('openid.discovery');
+}


### PR DESCRIPTION
When using Laravel with Passport, we have enough knowledge of the environment
to be able to provide 2 useful routes our of the box:

a discovery endpoint at /.well-known/openid-configuration.
a JWKS endpoint at /oauth/jwks.
This greatly eases integrating with Laravel since clients can now
use auto-discovery to integrate with Laravel + PassPort + OpenID.

This PR has been successfully tested using the Javascript openid-client package.
This PR is based on https://github.com/ronvanderheijden/openid-connect/pull/16

Ref: https://github.com/jeremy379/laravel-openid-connect/issues/9 
Thanks go to @moufmouf