### PR TITLE
Improved OIDC Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Example:
 'token_headers' => ['kid' => base64_encode('public-key-added-2023-01-01')]
 ```
 
+Additionally, you can configure the JWKS url and some settings for discovery in the config file.
+
 ## Support
 
 You can fill an issue in the github section dedicated for that. I'll try to maintain this fork.

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -80,9 +80,11 @@ class IdTokenResponse extends BearerTokenResponse {
          */
         $scopes = $accessToken->getScopes();
 
-        $params = ['scope' => implode(' ', array_map(function ($value) {
-            return $value->getIdentifier();
-        }, $scopes))];
+        $params = [
+            'scope' => implode(' ', array_map(function ($value) {
+                return $value->getIdentifier();
+            }, $scopes)),
+        ];
 
         if (!$this->hasOpenIDScope(...$scopes)) {
             return $params;

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -78,9 +78,13 @@ class IdTokenResponse extends BearerTokenResponse {
          *
          *  The value of the scope parameter is expressed as a list of space-delimited, case-sensitive strings.
          */
-        $params = ['scope' => implode(' ', $accessToken->getScopes())];
+        $scopes = $accessToken->getScopes();
 
-        if (!$this->hasOpenIDScope(...$accessToken->getScopes())) {
+        $params = ['scope' => implode(' ', array_map(function ($value) {
+            return $value->getIdentifier();
+        }, $scopes))];
+
+        if (!$this->hasOpenIDScope(...$scopes)) {
             return $params;
         }
 
@@ -106,7 +110,7 @@ class IdTokenResponse extends BearerTokenResponse {
         }
 
         $claims = $this->claimExtractor->extract(
-            $accessToken->getScopes(),
+            $scopes,
             $user->getClaims(),
         );
 

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -4,32 +4,28 @@ namespace OpenIDConnect\Laravel;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Laravel\Passport\Passport;
 
 class DiscoveryController
 {
+    /**
+     * Compatible with https://openid.net/specs/openid-connect-discovery-1_0.html, chapter 3
+     */
     public function __invoke(Request $request)
     {
         $response = [
             'issuer' => url('/'),
             'authorization_endpoint' => route('passport.authorizations.authorize'),
             'token_endpoint' => route('passport.token'),
-            'response_types_supported' => [
-                'code',
-                'token',
-                'id_token',
-                'code token',
-                'code id_token',
-                'token id_token',
-                'code token id_token',
-                'none',
-            ],
+            'grant_types_supported' => $this->getSupportedGrantTypes(),
+            'response_types_supported' => $this->getSupportedResponseTypes(),
             'subject_types_supported' => [
                 'public',
             ],
             'id_token_signing_alg_values_supported' => [
                 'RS256',
             ],
-            'scopes_supported' => config('openid.passport.tokens_can'),
+            'scopes_supported' => $this->getSupportedScopes(),
             'token_endpoint_auth_methods_supported' => [
                 'client_secret_basic',
                 'client_secret_post',
@@ -45,5 +41,77 @@ class DiscoveryController
         }
 
         return response()->json($response, 200, [], JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * Returns JSON array containing a list of the OAuth 2.0 [RFC6749] scope values that this server supports.
+     * The server MUST support the openid scope value. Servers MAY choose not to advertise some supported scope values even when this parameter is used,
+     * although those defined in [OpenID.Core] SHOULD be listed, if supported.
+     */
+    private function getSupportedScopes(): array {
+        $scopes = array_keys(config('openid.passport.tokens_can'));
+
+        if (!config('openid.hide_scopes', false)) {
+            return $scopes;
+        }
+
+        /**
+         * Otherwise, only return scopes from the OpenID Core Spec, section 5.4
+         */
+        return array_intersect($scopes, [
+            'openid',
+            'profile',
+            'email',
+            'address',
+            'phone'
+        ]);
+    }
+
+    private function getSupportedGrantTypes(): array {
+        // See PassportServiceProvider for grant types that cannot be disabled
+        $grants = [
+            'authorization_code', // Cannot be disabled in Passport
+            'client_credentials', // Cannot be disabled in Passport
+            'refresh_token',  // Cannot be disabled in Passport
+        ];
+
+        if (Passport::$implicitGrantEnabled) {
+            $grants[] = "implicit";
+        }
+
+        if (Passport::$passwordGrantEnabled) {
+            $grants[] = "password";
+        }
+
+        return $grants;
+    }
+
+    /**
+     * Returns JSON array containing a list of the OAuth 2.0 response_type values that this OP supports.
+     * Dynamic OpenID Providers MUST support the code, id_token, and the id_token token Response Type values.
+     */
+    private function getSupportedResponseTypes(): array {
+        /**
+         * These are always possible with Auth Code Grant
+         */
+        $response_types = [
+            'code',
+            'id_token',
+            'code id_token',
+        ];
+
+        if (Passport::$implicitGrantEnabled) {
+            /**
+             * Return all variants, indicating both Auth Code & implicit are allowed
+             */
+            return array_merge($response_types, [
+                'token',
+                'code token',
+                'token id_token',
+                'code token id_token',
+            ]);
+        }
+
+        return $response_types;
     }
 }

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -97,12 +97,6 @@ class DiscoveryController
          */
         $response_types = [
             'code',
-            /**
-             * Passport does not actually support `code id_token` or `id_token` and
-             * we return the ID token regardless on all requests.
-             *
-             * This doesn't form a problem however, even the OIDC spec doesn't do this correctly.
-             */
         ];
 
         if (Passport::$implicitGrantEnabled) {
@@ -112,8 +106,10 @@ class DiscoveryController
             return array_merge($response_types, [
                 'token',
                 /**
-                 * Passport doesn't support `code token` either.
-                 */
+                * TODO: Allow `id_token`, `id_token token`, `code id_token`, `code token`, `code id_token token`
+                * if we build the Implict Flow path.
+                * See https://github.com/jeremy379/laravel-openid-connect/issues/6
+                */
             ]);
         }
 

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -96,8 +96,12 @@ class DiscoveryController
          */
         $response_types = [
             'code',
-            'id_token',
-            'code id_token',
+            /**
+             * Passport does not actually support `code id_token` or `id_token` and
+             * we return the ID token regardless on all requests.
+             *
+             * This doesn't form a problem however, even the OIDC spec doesn't do this correctly.
+             */
         ];
 
         if (Passport::$implicitGrantEnabled) {
@@ -105,10 +109,10 @@ class DiscoveryController
              * Return all variants, indicating both Auth Code & implicit are allowed
              */
             return array_merge($response_types, [
-                'token',
-                'code token',
-                'token id_token',
-                'code token id_token',
+                'token'
+                /**
+                 * Passport doesn't support `code token` either.
+                 */
             ]);
         }
 

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -63,7 +63,7 @@ class DiscoveryController
             'profile',
             'email',
             'address',
-            'phone'
+            'phone',
         ]);
     }
 
@@ -109,7 +109,7 @@ class DiscoveryController
              * Return all variants, indicating both Auth Code & implicit are allowed
              */
             return array_merge($response_types, [
-                'token'
+                'token',
                 /**
                  * Passport doesn't support `code token` either.
                  */

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -52,7 +52,7 @@ class DiscoveryController
     private function getSupportedScopes(): array {
         $scopes = array_keys(config('openid.passport.tokens_can'));
 
-        if (!config('openid.hide_scopes', false)) {
+        if (!config('openid.discovery.hide_scopes', false)) {
             return $scopes;
         }
 

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -45,7 +45,8 @@ class DiscoveryController
 
     /**
      * Returns JSON array containing a list of the OAuth 2.0 [RFC6749] scope values that this server supports.
-     * The server MUST support the openid scope value. Servers MAY choose not to advertise some supported scope values even when this parameter is used,
+     * The server MUST support the openid scope value. 
+     * Servers MAY choose not to advertise some supported scope values even when this parameter is used,
      * although those defined in [OpenID.Core] SHOULD be listed, if supported.
      */
     private function getSupportedScopes(): array {

--- a/src/Laravel/config/openid.php
+++ b/src/Laravel/config/openid.php
@@ -70,4 +70,10 @@ return [
      * By default, microseconds are included.
      */
     'use_microseconds' => true,
+
+    /**
+     * Hide scopes that aren't from the OpenID Core spec from the Discovery,
+     * default = false (all scopes are listed)
+     */
+    'hide_scopes' => false,
 ];

--- a/src/Laravel/config/openid.php
+++ b/src/Laravel/config/openid.php
@@ -57,6 +57,17 @@ return [
     ],
 
     /**
+     * Settings for the discovery endpoint
+     */
+    'discovery' => [
+        /**
+        * Hide scopes that aren't from the OpenID Core spec from the Discovery,
+        * default = false (all scopes are listed)
+        */
+        'hide_scopes' => false,
+    ]
+
+    /**
      * The signer to be used
      */
 	'signer' => \Lcobucci\JWT\Signer\Rsa\Sha256::class,
@@ -70,10 +81,4 @@ return [
      * By default, microseconds are included.
      */
     'use_microseconds' => true,
-
-    /**
-     * Hide scopes that aren't from the OpenID Core spec from the Discovery,
-     * default = false (all scopes are listed)
-     */
-    'hide_scopes' => false,
 ];

--- a/src/Laravel/config/openid.php
+++ b/src/Laravel/config/openid.php
@@ -65,7 +65,7 @@ return [
         * default = false (all scopes are listed)
         */
         'hide_scopes' => false,
-    ]
+    ],
 
     /**
      * The signer to be used


### PR DESCRIPTION
Improved the discovery document to be correct. 

We only support `code` and `token` for `grant_types_supported`, as this library only supports `Auth Code Flow` by default and does not add the Implicit Flow and Hybrid Flow grant types (https://openid.net/specs/openid-connect-core-1_0.html#Authentication)

Sorry for the second PR so soon, did not expect you to create a release so fast ;)
Luckily this one can be a patch to 2.2.1 as everything is optional and there is no backwards incompatibility. Default behaviour for scopes is the same.