### PR TITLE
Added support for the 'kid' token header in the JWKsController

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Example:
 
 Additionally, you can configure the JWKS url and some settings for discovery in the config file.
 
+_Note: If you define a `kid` header, it will be added to the JWK returned at the jwks_url (if `jwks` is enabled in the configuration)._
+
 ## Support
 
 You can fill an issue in the github section dedicated for that. I'll try to maintain this fork.

--- a/src/Laravel/JwksController.php
+++ b/src/Laravel/JwksController.php
@@ -12,15 +12,22 @@ class JwksController
         // Source: https://www.tuxed.net/fkooman/blog/json_web_key_set.html
         $keyInfo = openssl_pkey_get_details(openssl_pkey_get_public($publicKey));
 
+        $passportJWK = [
+            'alg' => 'RS256',
+            'kty' => 'RSA',
+            'use' => 'sig',
+            'n' => rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($keyInfo['rsa']['n'])), '='),
+            'e' => rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($keyInfo['rsa']['e'])), '='),
+        ];
+
+        // Adds the kid if it is set in the config's token_headers
+        if ($kid = config('openid.token_headers.kid', false)) {
+            $passportJWK['kid'] = $kid;
+        }
+
         $jsonData = [
             'keys' => [
-                [
-                    'alg' => 'RS256',
-                    'kty' => 'RSA',
-                    'use' => 'sig',
-                    'n' => rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($keyInfo['rsa']['n'])), '='),
-                    'e' => rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($keyInfo['rsa']['e'])), '='),
-                ],
+                $passportJWK,
             ],
         ];
 


### PR DESCRIPTION
Super small PR aiming to improve the response of JWKs response to include the key's `kid` when it has been defined in `openid.token_headers`. 
It does not have any breaking changes as the `kid` key is only ever returned the JWKs response when it has been defined but brings consistency to the use of `kid` as outlined in the readme.