### PR TITLE
Add end_session_endpoint key for RP-Initiated Logout to DiscoveryController

### DIFF
--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -40,6 +40,10 @@ class DiscoveryController
             $response['jwks_uri'] = route('openid.jwks');
         }
 
+        if (Route::has('openid.end_session_endpoint')) {
+            $response['end_session_endpoint'] = route('openid.end_session_endpoint');
+        }
+
         return response()->json($response, 200, [], JSON_PRETTY_PRINT);
     }
 


### PR DESCRIPTION
I've added a way to add the 'end_session_endpoint' route to the OpenID Discovery response.
With this endpoint, clients can initiate a remote logout.

See https://openid.net/specs/openid-connect-rpinitiated-1_0.html