### PR TITLE
Use the same issuer in token and discovery responses

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -58,7 +58,7 @@ class IdTokenResponse extends BearerTokenResponse {
         return $this->config
             ->builder()
             ->permittedFor($accessToken->getClient()->getIdentifier())
-            ->issuedBy(url('/'))
+            ->issuedBy('https://' . $_SERVER['HTTP_HOST'])
             ->issuedAt($dateTimeImmutableObject)
             ->expiresAt($dateTimeImmutableObject->add(new DateInterval('PT1H')))
             ->relatedTo($userEntity->getIdentifier());

--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -55,17 +55,10 @@ class IdTokenResponse extends BearerTokenResponse {
             ($this->useMicroseconds ? microtime(true) : time())
         );
 
-        if ($this->currentRequestService) {
-            $uri = $this->currentRequestService->getRequest()->getUri();
-            $issuer = $uri->getScheme() . '://' . $uri->getHost() . ($uri->getPort() ? ':' . $uri->getPort() : '');
-        } else {
-            $issuer = 'https://' . $_SERVER['HTTP_HOST'];
-        }
-
         return $this->config
             ->builder()
             ->permittedFor($accessToken->getClient()->getIdentifier())
-            ->issuedBy($issuer)
+            ->issuedBy(url('/'))
             ->issuedAt($dateTimeImmutableObject)
             ->expiresAt($dateTimeImmutableObject->add(new DateInterval('PT1H')))
             ->relatedTo($userEntity->getIdentifier());

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -4,6 +4,7 @@ namespace OpenIDConnect\Laravel;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 use Laravel\Passport\Passport;
 
 class DiscoveryController
@@ -13,10 +14,12 @@ class DiscoveryController
      */
     public function __invoke(Request $request)
     {
+        URL::forceScheme('https'); // for route() calls below
+
         $response = [
             'issuer' => 'https://' . $_SERVER['HTTP_HOST'],
             'authorization_endpoint' => route('passport.authorizations.authorize'),
-            'token_endpoint' => str_replace('http://', 'https://', route('passport.token')),
+            'token_endpoint' => route('passport.token'),
             'grant_types_supported' => $this->getSupportedGrantTypes(),
             'response_types_supported' => $this->getSupportedResponseTypes(),
             'subject_types_supported' => [
@@ -33,15 +36,15 @@ class DiscoveryController
         ];
 
         if (Route::has('openid.userinfo')) {
-            $response['userinfo_endpoint'] = str_replace('http://', 'https://', route('openid.userinfo'));
+            $response['userinfo_endpoint'] = route('openid.userinfo');
         }
 
         if (Route::has('openid.jwks')) {
-            $response['jwks_uri'] = str_replace('http://', 'https://', route('openid.jwks'));
+            $response['jwks_uri'] = route('openid.jwks');
         }
 
         if (Route::has('openid.end_session_endpoint')) {
-            $response['end_session_endpoint'] = str_replace('http://', 'https://', route('openid.end_session_endpoint'));
+            $response['end_session_endpoint'] = route('openid.end_session_endpoint');
         }
 
         return response()->json($response, 200, [], JSON_PRETTY_PRINT);

--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -14,9 +14,9 @@ class DiscoveryController
     public function __invoke(Request $request)
     {
         $response = [
-            'issuer' => url('/'),
+            'issuer' => 'https://' . $_SERVER['HTTP_HOST'],
             'authorization_endpoint' => route('passport.authorizations.authorize'),
-            'token_endpoint' => route('passport.token'),
+            'token_endpoint' => str_replace('http://', 'https://', route('passport.token')),
             'grant_types_supported' => $this->getSupportedGrantTypes(),
             'response_types_supported' => $this->getSupportedResponseTypes(),
             'subject_types_supported' => [
@@ -33,15 +33,15 @@ class DiscoveryController
         ];
 
         if (Route::has('openid.userinfo')) {
-            $response['userinfo_endpoint'] = route('openid.userinfo');
+            $response['userinfo_endpoint'] = str_replace('http://', 'https://', route('openid.userinfo'));
         }
 
         if (Route::has('openid.jwks')) {
-            $response['jwks_uri'] = route('openid.jwks');
+            $response['jwks_uri'] = str_replace('http://', 'https://', route('openid.jwks'));
         }
 
         if (Route::has('openid.end_session_endpoint')) {
-            $response['end_session_endpoint'] = route('openid.end_session_endpoint');
+            $response['end_session_endpoint'] = str_replace('http://', 'https://', route('openid.end_session_endpoint'));
         }
 
         return response()->json($response, 200, [], JSON_PRETTY_PRINT);


### PR DESCRIPTION
OIDC clients compare discovered issuer with token's issuer. So, these must be the same.

Mentioned in #23.