### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     "require": {
         "php": "^8.1",
         "lcobucci/jwt": "^4.0|^4.3|^5.0",
-        "league/oauth2-server": "^8.2.0",
+        "league/oauth2-server": "^8.2.0|^9.2.0",
         "laravel/passport": "^11.0|^12.0",
-        "laravel/framework": "^10.0|^11.0",
+        "laravel/framework": "^10.0|^11.0|^12.0",
         "ext-openssl": "*"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.7",
+        "guzzlehttp/psr7": "^1.7|^2.7.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "overtrue/phplint": "^9.0",
         "phpunit/phpunit": "^9.4.2",


### PR DESCRIPTION
I was looking at https://github.com/jeremy379/laravel-openid-connect/pull/34 and saw that @alecpl said:

"As far as I can see, the symplify/easy-coding-standard version bump is not required. It brakes CS check. If we wanted that bump we'll need changes in ecs.php file according to https://tomasvotruba.com/blog/new-in-ecs-simpler-config/."

So this is that same PR without updating `slevomat/coding-standard` or `symplify/easy-coding-standard`.