### PR TITLE
Passport v13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^8.1",
         "lcobucci/jwt": "^4.0|^4.3|^5.0",
         "league/oauth2-server": "^8.2.0|^9.2.0",
-        "laravel/passport": "^11.0|^12.0",
+        "laravel/passport": "^11.0|^12.0|^13.0",
         "laravel/framework": "^10.0|^11.0|^12.0",
         "ext-openssl": "*"
     },
@@ -34,7 +34,7 @@
         "guzzlehttp/psr7": "^1.7|^2.7.0",
         "http-interop/http-factory-guzzle": "^1.0",
         "overtrue/phplint": "^9.0",
-        "phpunit/phpunit": "^9.4.2",
+        "phpunit/phpunit": "^10.5.0",
         "slevomat/coding-standard": "^6.4.1",
         "slim/slim": "4.*",
         "symplify/easy-coding-standard": "^9.2",
@@ -80,7 +80,8 @@
     },
     "config": {
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "php-http/discovery": false
         }
     }
 }

--- a/src/Interfaces/IdentityEntityInterface.php
+++ b/src/Interfaces/IdentityEntityInterface.php
@@ -7,5 +7,5 @@ use OpenIDConnect\Claims\Claimable;
 
 interface IdentityEntityInterface extends Claimable, OAuth2UserEntityInterface
 {
-    public function getIdentifier();
+    public function getIdentifier(): string;
 }


### PR DESCRIPTION
Also
- fixed PHP Fatal error: Declaration of OpenIDConnect\Interfaces\IdentityEntityInterface::getIdentifier() must be compatible with League\OAuth2\Server\Entities\UserEntityInterface::getIdentifier(): string
- bumped phpunit to v10 (fixes warnings about the config file).

ps. I did not test if it works in a real life application, but tests here pass.