### PR TITLE
Don't force https

### DIFF
--- a/src/Laravel/DiscoveryController.php
+++ b/src/Laravel/DiscoveryController.php
@@ -15,8 +15,6 @@ class DiscoveryController
      */
     public function __invoke(Request $request, LaravelCurrentRequestService $currentRequestService)
     {
-        URL::forceScheme('https'); // for route() calls below
-
         $response = [
             'issuer' => IssuedByGetter::get($currentRequestService, config('openid.issuedBy', 'laravel')),
             'authorization_endpoint' => route('passport.authorizations.authorize'),


### PR DESCRIPTION
It is better to let the generated URL use the scheme (HTTP or HTTPS) and host from the current request being handled by the application.

This ensures that discovery will work in both **HTTP (for local development)** and **HTTPS (in production)**.