### PR TITLE
fix: corrected response handling in openid repository classes

### DIFF
--- a/src/Repositories/AccessTokenRepository.php
+++ b/src/Repositories/AccessTokenRepository.php
@@ -9,7 +9,7 @@ use OpenIDConnect\Entities\AccessTokenEntity;
 
 class AccessTokenRepository implements AccessTokenRepositoryInterface
 {
-    public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
+    public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null): AccessTokenEntity
     {
         $accessToken = new AccessTokenEntity();
         $accessToken->setClient($clientEntity);
@@ -21,15 +21,15 @@ class AccessTokenRepository implements AccessTokenRepositoryInterface
         return $accessToken;
     }
 
-    public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity)
+    public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity): void
     {
     }
 
-    public function revokeAccessToken($tokenId)
+    public function revokeAccessToken($tokenId): void
     {
     }
 
-    public function isAccessTokenRevoked($tokenId)
+    public function isAccessTokenRevoked($tokenId): bool
     {
         return false;
     }

--- a/src/Repositories/AuthCodeRepository.php
+++ b/src/Repositories/AuthCodeRepository.php
@@ -8,20 +8,20 @@ use OpenIDConnect\Entities\AuthCodeEntity;
 
 class AuthCodeRepository implements AuthCodeRepositoryInterface
 {
-    public function getNewAuthCode()
+    public function getNewAuthCode(): AuthCodeEntity
     {
         return new AuthCodeEntity();
     }
 
-    public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity)
+    public function persistNewAuthCode(AuthCodeEntityInterface $authCodeEntity): void
     {
     }
 
-    public function revokeAuthCode($codeId)
+    public function revokeAuthCode($codeId): void
     {
     }
 
-    public function isAuthCodeRevoked($codeId)
+    public function isAuthCodeRevoked($codeId): bool
     {
         return false;
     }

--- a/src/Repositories/ClientRepository.php
+++ b/src/Repositories/ClientRepository.php
@@ -7,7 +7,7 @@ use OpenIDConnect\Entities\ClientEntity;
 
 class ClientRepository implements ClientRepositoryInterface
 {
-    public function getClientEntity($clientIdentifier)
+    public function getClientEntity($clientIdentifier): ClientEntity
     {
         $client = new ClientEntity();
         $client->setIdentifier('1');
@@ -16,7 +16,7 @@ class ClientRepository implements ClientRepositoryInterface
         return $client;
     }
 
-    public function validateClient($clientIdentifier, $clientSecret, $grantType)
+    public function validateClient($clientIdentifier, $clientSecret, $grantType): bool
     {
         return true;
     }

--- a/src/Repositories/RefreshTokenRepository.php
+++ b/src/Repositories/RefreshTokenRepository.php
@@ -8,20 +8,20 @@ use OpenIDConnect\Entities\RefreshTokenEntity;
 
 class RefreshTokenRepository implements RefreshTokenRepositoryInterface
 {
-    public function getNewRefreshToken()
+    public function getNewRefreshToken(): RefreshTokenEntity
     {
         return new RefreshTokenEntity();
     }
 
-    public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
+    public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity): void
     {
     }
 
-    public function revokeRefreshToken($tokenId)
+    public function revokeRefreshToken($tokenId): void
     {
     }
 
-    public function isRefreshTokenRevoked($tokenId)
+    public function isRefreshTokenRevoked($tokenId): bool
     {
         return false;
     }


### PR DESCRIPTION
This PR fixes a compatibility issue where repository methods did not match their interface return types, causing failures when generating authorization codes and tokens. The issue was detected in Laravel 12, where stricter return type enforcement made the mismatch problematic.

# Steps to Reproduce
1. Install Laravel 12 with Passport and Laravel OpenID Connect package.
2. Register a client application (e.g., Nextcloud) using the discovery endpoint.
3. Attempt to authenticate via the client using the authorization code flow.
4. Observe the error: method signature mismatch or return type inconsistency between interface and implementation.

# How to test
1. Apply the proposed fix in the package.
2. Repeat the steps to reproduce.
3. Confirm that the login process completes successfully and tokens are issued as expected.


![image-1-2025-07-04_15-43](https://github.com/user-attachments/assets/191ed4b4-e96d-4691-8d29-3f933281d537)

 
![image-4-2025-07-04_15-43](https://github.com/user-attachments/assets/6fda0d04-ee00-4d12-92cb-d045ae6b100d)
