### PR TITLE
fix: handle null passport.public_key config value in getPublicKey() method

### DIFF
--- a/src/Laravel/JwksController.php
+++ b/src/Laravel/JwksController.php
@@ -35,7 +35,7 @@ class JwksController
     }
 
     private function getPublicKey(): string {
-        $publicKey = str_replace('\\n', "\n", config('passport.public_key', ''));
+        $publicKey = str_replace('\\n', "\n", config('passport.public_key') ?? '');
 
         if (!$publicKey) {
             $publicKey = 'file://'.Passport::keyPath('oauth-public.key');


### PR DESCRIPTION
Replace empty string fallback with null coalescing operator to prevent `str_replace()` deprecation warning when `passport.public_key` is null

The current code uses `config('passport.public_key', '')` which doesn't provide the expected empty string fallback when the config key exists but has a null value.
No `PASSPORT_PUBLIC_KEY` set in `.env` and `'public_key' => env('PASSPORT_PUBLIC_KEY')` then evaluates to null, so does the `config('passport.public_key', '')` (no fallback to empty string)

This causes `str_replace()` to receive null as the subject parameter, triggering a PHP deprecation warning:

`str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`