### PR TITLE
Authorization Blade View is no longer supplied by default in laravel/passport v13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ $scopes = array_merge($yourScopes, config('openid.passport.tokens_can'));
 Passport::tokensCan($scopes);
 ````
 
+### Register the authorization view
+
+Laravel passport v13+ does not automatically register the authorization view resulting in an `BindingResolutionException` when you access the /oauth/authorize endpoint, we need to tell passport which view to use
+
+You can add it to your `AuthServiceProvider`
+
+```php
+    public function boot(): void
+    {
+        Passport::authorizationView('auth.oauth.authorize');
+    }
+```
+
 ### Register package passport provider
 
 In `boostrap/providers.php`, add `\OpenIDConnect\Laravel\PassportServiceProvider::class`


### PR DESCRIPTION
Hi there,

If you would do a clean install using laravel/passport v13+ and your package you will most likely run into the following issue:
https://github.com/laravel/passport/issues/1832

I added a section to the readme that explains how to set it up correctly to mirror the behavior of v12.
