### PR TITLE
Fix PHP 8.4 deprecation warnings in IdTokenResponse constructor

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -31,8 +31,8 @@ class IdTokenResponse extends BearerTokenResponse {
         Configuration $config,
         array $tokenHeaders = [],
         bool $useMicroseconds = true,
-        CurrentRequestServiceInterface $currentRequestService = null,
-        $encryptionKey = null,
+        ?CurrentRequestServiceInterface $currentRequestService = null,
+        string|Key|null $encryptionKey = null,
         protected string $issuedByConfigured = 'laravel',
     ) {
         $this->identityRepository = $identityRepository;


### PR DESCRIPTION
This PR fixes PHP 8.4 deprecation warnings caused by implicit nullable type declarations in the IdTokenResponse constructor.

PHP 8.4 deprecates implicitly marking parameters as nullable by only providing a null default value. This was causing the following deprecation warning:
```
OpenIDConnect\IdTokenResponse::__construct(): Implicitly marking parameter $currentRequestService as nullable is deprecated, the explicit nullable type must be used instead
```