### PR TITLE
fix: prevent DateTimeImmutable::createFromFormat() returning false (#56)

### DIFF
--- a/src/IdTokenResponse.php
+++ b/src/IdTokenResponse.php
@@ -50,8 +50,14 @@ class IdTokenResponse extends BearerTokenResponse {
     ): Builder {
         $dateTimeImmutableObject = DateTimeImmutable::createFromFormat(
             ($this->useMicroseconds ? 'U.u' : 'U'),
-            ($this->useMicroseconds ? microtime(true) : time())
+            ($this->useMicroseconds ? number_format(microtime(true), 6, '.', '') : (string) time())
         );
+
+        if ($dateTimeImmutableObject === false) {
+            throw new \RuntimeException(
+                'Failed to create DateTimeImmutable: ' . print_r(DateTimeImmutable::getLastErrors(), true)
+            );
+        }
 
         return $this->config
             ->builder()


### PR DESCRIPTION
## Problem

When `useMicroseconds` is `true`, `microtime(true)` returns a PHP `float` that is cast to string before being passed to `DateTimeImmutable::createFromFormat()`. In rare cases where the microseconds portion is exactly zero, the float is stringified **without a decimal point** (e.g. `1711878310.0` → `"1711878310"`), which doesn't match the `'U.u'` format. `createFromFormat()` returns `false`, and that `false` is passed straight to `->issuedAt()`, causing:

```
TypeError: Lcobucci\JWT\Token\Builder::issuedAt(): Argument #1 ($issuedAt) must be of type DateTimeImmutable, bool given
```

This is a timing-dependent edge case, which explains why it's hard to reproduce.

## Fix

- Use `number_format(microtime(true), 6, '.', '')` to always produce a string with 6 decimal places (e.g. `"1711878310.000000"`), guaranteeing a valid match for the `'U.u'` format.
- Add a defensive guard: if `createFromFormat()` still returns `false` for any unexpected reason, throw a descriptive `RuntimeException` with `DateTimeImmutable::getLastErrors()` details — instead of letting an opaque `TypeError` surface from deep inside `lcobucci/jwt`.

Fixes #56