### PR TITLE
Add PHP 8.5 CI workflow and fix deprecated ReflectionMethod::setAccessible() 

### DIFF
--- a/.github/workflows/php85.yml
+++ b/.github/workflows/php85.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
+jobs:
+  checks:
+    name: Check PHP 8.5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up PHP 8.5
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: '8.5'
+
+      - name: Install Dependencies
+        run: composer install --prefer-dist --no-interaction
+
+      - name: Check code styling
+        run: composer ecs-check
+
+      - name: Create keys
+        run: sh ./bin/create_keys
+
+      - name: Run unit and feature tests
+        run: composer test

--- a/tests/Feature/IdTokenCustomAudTest.php
+++ b/tests/Feature/IdTokenCustomAudTest.php
@@ -57,8 +57,6 @@ class IdTokenCustomAudTest extends TestCase
 
         $reflection = new \ReflectionClass($idTokenResponse);
         $getExtraParams = $reflection->getMethod('getExtraParams');
-        $getExtraParams->setAccessible(true);
-
         $params = $getExtraParams->invoke($idTokenResponse, $accessToken);
 
         $this->assertArrayHasKey('id_token', $params);


### PR DESCRIPTION
 ## What                                                                                                                                                                                                                          
                                                                                                                                                                                                                                   
  - Adds `.github/workflows/php85.yml` to run tests against PHP 8.5                                                                                                                                                                
  - Removes `ReflectionMethod::setAccessible()` call in `IdTokenCustomAudTest`,                                                                                                                                                    
    deprecated since PHP 8.5 (it has had no effect since PHP 8.1)                                                                                                                                                                  
                                                                                                                                                                                                                                   
  ## Why                                                                                                                                                                                                                           
                                                                                                                                                                                                                                   
  PHP 8.5 deprecates `ReflectionMethod::setAccessible()`. Without this fix,                                                                                                                                                        
  the two tests in `IdTokenCustomAudTest` emit a deprecation warning on 8.5.                                                                                                                                                       
  All 45 tests pass cleanly with no deprecations after the change.                                                                                                                                                                 
                                                                                                                                                                                                                                   
  ## Testing                                                                                                                                                                                                                       
                                                                                                                                                                                                                                   
  Tested locally on PHP 8.5.7:                                                                                                                                                                                                     
                                                                                                                                                                                                                                   
  OK (45 tests, 105 assertions)